### PR TITLE
Add getLevel() method

### DIFF
--- a/src/com/esotericsoftware/minlog/Log.java
+++ b/src/com/esotericsoftware/minlog/Log.java
@@ -35,6 +35,8 @@ public class Log {
 	/** True when the TRACE level will be logged. */
 	static public boolean TRACE = level <= LEVEL_TRACE;
 
+	static public int getLevel() { return level; }
+	
 	/** Sets the level to log. If a version of this class is being used that has a final log level, this has no affect. */
 	static public void set (int level) {
 		// Comment out method contents when compiling fixed level JARs.

--- a/src/com/esotericsoftware/minlog/Log.java
+++ b/src/com/esotericsoftware/minlog/Log.java
@@ -35,8 +35,10 @@ public class Log {
 	/** True when the TRACE level will be logged. */
 	static public boolean TRACE = level <= LEVEL_TRACE;
 
-	static public int getLevel() { return level; }
-	
+	static public int getLevel () {
+		return level;
+	}
+
 	/** Sets the level to log. If a version of this class is being used that has a final log level, this has no affect. */
 	static public void set (int level) {
 		// Comment out method contents when compiling fixed level JARs.


### PR DESCRIPTION
Currently there are multiple ways to set Minlog's logging level, but no way to know programatically what level that is set to. I added a single-line `getLevel()` method to expose what level the log is set for.